### PR TITLE
Feat: add styling for header and footer

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,11 +1,13 @@
-import { Layout } from "./components/common";
+import { Layout, Header, Footer } from "./components/common";
 
 function App() {
   return (
-		<Layout>
-			hello
-		</Layout>
-	);
+    <div>
+      <Header>헤더</Header>
+      <Layout>hello</Layout>
+      <Footer>푸터</Footer>
+    </div>
+  );
 }
 
 export default App;

--- a/src/components/common/Layout.tsx
+++ b/src/components/common/Layout.tsx
@@ -1,26 +1,60 @@
-import React from 'react'
-import styled from "styled-components"
+import React from "react";
+import styled from "styled-components";
 
-interface LayoutProps {
-	children: React.ReactNode
+interface CommonProps {
+  children: React.ReactNode;
 }
 
-function Layout({children}: LayoutProps) {
-	return (
-		<Wrapper>
-			{children}
-		</Wrapper>
-	)
+function Layout({ children }: CommonProps) {
+  return <Wrapper>{children}</Wrapper>;
 }
+
+function Header({ children }: CommonProps) {
+  return <HeaderStyled>{children}</HeaderStyled>;
+}
+
+function Footer({ children }: CommonProps) {
+  return <FooterStyled>{children}</FooterStyled>;
+}
+
+const HeaderStyled = styled.div`
+  background-color: #c7fced;
+  position: fixed;
+  transform: translateX(-50%);
+  z-index: 1;
+  top: 0;
+  left: 50%;
+  width: 360px;
+  height: 52px;
+  display: flex;
+  margin-top: 24px;
+  justify-content: space-around;
+  align-items: center;
+`;
+
+const FooterStyled = styled.div`
+  background-color: #29d3c6;
+  position: fixed;
+  transform: translateX(-50%);
+  bottom: 0;
+  left: 50%;
+  width: 360px;
+  height: 67px;
+  display: flex;
+  justify-content: space-around;
+  align-items: center;
+`;
 
 const Wrapper = styled.div`
-	position: fixed;
-	bottom: 0;
-	top: 0;
-	left: 50%;
-	transform: translateX(-50%);
-	width: 360px;
-	background-color: white;
-`
+  position: fixed;
+  bottom: 0;
+  top: 0;
+  left: 50%;
+  transform: translateX(-50%);
+  width: 360px;
+  background-color: white;
+`;
 
-export {Layout}
+export { Layout };
+export { Header };
+export { Footer };


### PR DESCRIPTION
헤더와 푸터 부분 기본적인 배치 스타일링만 추가했습니다. 
헤더 부분 배치할 때, 기존의 레이아웃 요소에 가려 보이지 않는 부분을 해결하고자
z-index를 추가했는데요. 혹시 z-index말고는 또 어떤 방법을 사용할 수 있을까요?
