### PR TITLE
Feature/earth section layout

### DIFF
--- a/src/components/Main/EarthSection/EarthImage.tsx
+++ b/src/components/Main/EarthSection/EarthImage.tsx
@@ -1,0 +1,26 @@
+import styled from 'styled-components';
+
+interface EarthImageProps {
+  imageSrc: string;
+}
+
+function EarthImage({imageSrc}: EarthImageProps) {
+  return (
+    <ImageWrapper>
+      <Img src={imageSrc} alt="지구 이미지" />
+    </ImageWrapper>
+  );
+}
+
+const ImageWrapper = styled.div`
+  margin-top: 4.798rem;
+  margin-bottom: 0.86rem;
+  text-align: center;
+`;
+
+const Img = styled.img`
+  width: 10.318rem;
+  height: 10.318rem;
+`;
+
+export {EarthImage};

--- a/src/components/Main/EarthSection/EarthImage.tsx
+++ b/src/components/Main/EarthSection/EarthImage.tsx
@@ -1,4 +1,5 @@
 import styled from 'styled-components';
+import color from 'color';
 
 interface EarthImageProps {
   imageSrc: string;
@@ -7,20 +8,17 @@ interface EarthImageProps {
 function EarthImage({imageSrc}: EarthImageProps) {
   return (
     <ImageWrapper>
-      <Img src={imageSrc} alt="지구 이미지" />
+      <img src={imageSrc} alt="지구img" />
     </ImageWrapper>
   );
 }
 
 const ImageWrapper = styled.div`
-  margin-top: 4.798rem;
-  margin-bottom: 0.86rem;
-  text-align: center;
-`;
-
-const Img = styled.img`
   width: 10.318rem;
   height: 10.318rem;
+  background-color: ${color.primary};
+  margin: 4.798rem 6.25rem 0.86rem;
+  border-radius: 100%;
 `;
 
 export {EarthImage};

--- a/src/components/Main/EarthSection/EarthSection.tsx
+++ b/src/components/Main/EarthSection/EarthSection.tsx
@@ -1,0 +1,21 @@
+import {EarthImage} from './EarthImage';
+import EarthShort from './EarthShort';
+import styled from 'styled-components';
+
+interface EarthSectionProps {
+  imageSrc: string;
+}
+
+function EarthSection({imageSrc}: EarthSectionProps) {
+  return (
+    <Div>
+      <EarthImage imageSrc={imageSrc} />
+      <EarthShort amountOfTree={35}></EarthShort>
+    </Div>
+  );
+}
+
+const Div = styled.div`
+  margin-bottom: 35px;
+`;
+export default EarthSection;

--- a/src/components/Main/EarthSection/EarthShort.tsx
+++ b/src/components/Main/EarthSection/EarthShort.tsx
@@ -1,0 +1,35 @@
+import color from 'color';
+import styled from 'styled-components';
+
+interface EarthShortProps {
+  amountOfTree: number;
+}
+
+function EarthShort({amountOfTree}: EarthShortProps) {
+  return (
+    <Wrapper>
+      <Line>네이버스와 함께</Line>
+      <Line>지구에게 선물한 나무</Line>
+      <Line>
+        <Span>{amountOfTree}그루</Span>
+      </Line>
+    </Wrapper>
+  );
+}
+
+const Wrapper = styled.div`
+  font-size: 0.875rem;
+  line-height: 1.5rem;
+  width: 100%;
+  text-align: center;
+`;
+
+const Line = styled.div``;
+
+const Span = styled.span`
+  font-size: 1.5rem;
+  line-height: 2.25rem;
+  color: ${color.primary};
+`;
+
+export default EarthShort;

--- a/src/pages/My/MyTree.tsx
+++ b/src/pages/My/MyTree.tsx
@@ -1,6 +1,7 @@
 import {Layout} from 'components/common';
 import Header from 'components/common/Header';
 import Icon from 'components/Icon/Icon';
+import EarthSection from 'components/Main/EarthSection/EarthSection';
 import {TreeSection, TreeType} from 'components/My/TreeSection';
 import {css} from 'styled-components/macro';
 
@@ -28,7 +29,11 @@ const trees: TreeType[] = [
   },
 ];
 
-function MyTree() {
+interface MyTreeProps {
+  imageSrc: string;
+}
+
+function MyTree({imageSrc}: MyTreeProps) {
   return (
     <Layout>
       <Layout.Header>
@@ -37,6 +42,7 @@ function MyTree() {
         </Header>
       </Layout.Header>
       <Layout.ScrollMain>
+        <EarthSection imageSrc={imageSrc} />
         <TreeSection trees={trees} />
       </Layout.ScrollMain>
     </Layout>


### PR DESCRIPTION
# Purposed Changed
- '함께 심은 나무' 페이지의 tree section 상단에 들어갈 earth section입니다.
- * 나무 없을 때의 울상 지구 이미지가 들어가는 화면 부분 추가 예정
- 챌린지 참여 section 안에 들어갈 원형 tree+리워드토큰+챌린저 수 등을 담은 challengeCard 부분은 
2월 1일(화) 낮에 끝날 것 같아 우선 earth section 먼저 pr 남겨두는 점 양해 부탁드려요.
- 원형 tree 부분(challengeCard에 포함)도 오늘 오후 중으로 꼭 pr 남겨두겠습니다.

말씀드렸던 대로 진행하지 못한 점 정말 죄송합니다ㅜㅜ!
감사합니다.